### PR TITLE
fix: remove @semantic-release/git plugin to comply with branch protection rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,17 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
+      - name: Test npm authentication
+        run: |
+          echo "Token length: $(echo -n $NODE_AUTH_TOKEN | wc -c)"
+          npm whoami || true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: 20.8.1
           registry-url: 'https://registry.npmjs.org/'
+          token: ${{ secrets.NPM_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -47,16 +48,6 @@ jobs:
 
       - name: Build library
         run: pnpm build
-
-      - name: Debug NPM Auth
-        env:
-          NPM_TOKEN_TEST: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "Attempting npm whoami with the provided token..."
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN_TEST}" > ./.npmrc-test
-          npm whoami --userconfig ./.npmrc-test
-          echo "npm whoami command completed."
-          rm ./.npmrc-test
 
       - name: Semantic Release
         env:

--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,5 @@
 {
-  "branches": [
-    "main"
-  ],
+  "branches": ["main"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,7 @@
 {
-  "branches": ["main"],
+  "branches": [
+    "main"
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
@@ -26,16 +28,6 @@
         ],
         "successComment": false,
         "failComment": false
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "package.json",
-          "CHANGELOG.md"
-        ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]
   ]


### PR DESCRIPTION
Removes the @semantic-release/git plugin from .releaserc to prevent direct pushes to main, resolving branch protection rule violations during release.