### PR TITLE
fix(release): only upload real dist assets to GitHub releases

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -22,7 +22,7 @@
       {
         "assets": [
           {
-            "path": "dist/**/*",
+            "path": "dist/**/*.*",
             "label": "Distribution"
           }
         ],

--- a/.releaserc
+++ b/.releaserc
@@ -22,8 +22,12 @@
       {
         "assets": [
           {
-            "path": "dist/**/*.*",
-            "label": "Distribution"
+            "path": "dist/**/*.js",
+            "label": "JavaScript distribution"
+          },
+          {
+            "path": "dist/**/*.css",
+            "label": "CSS distribution"
           }
         ],
         "successComment": false,


### PR DESCRIPTION
- Update .releaserc to only include .js and .css files from dist/ as GitHub release assets
- Prevents upload errors from empty files or directories
- Ensures release workflow completes successfully

No changes to the library code or build output.