### PR TITLE
fix(release): update GitHub release assets config for dist files

### DIFF
--- a/.github/workflows/deploy-histoire.yml
+++ b/.github/workflows/deploy-histoire.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Build Histoire
         run: pnpm run story:build
 
+      - name: Ensure 404.html for client-side routing
+        run: cp histoire-dist/index.html histoire-dist/404.html
+
       - name: Check generated HTML
         run: cat histoire-dist/index.html
 
@@ -88,6 +91,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-
-      - name: Ensure 404.html for client-side routing
-        run: cp histoire-dist/index.html histoire-dist/404.html

--- a/.releaserc
+++ b/.releaserc
@@ -22,7 +22,7 @@
       {
         "assets": [
           {
-            "path": "dist/**/*",
+            "path": "dist/**/*.*",
             "label": "Distribution"
           }
         ],

--- a/.releaserc
+++ b/.releaserc
@@ -22,8 +22,12 @@
       {
         "assets": [
           {
-            "path": "dist/**/*.*",
-            "label": "Distribution"
+            "path": "dist/**/*.js",
+            "label": "JavaScript distribution"
+          },
+          {
+            "path": "dist/**/*.css",
+            "label": "CSS distribution"
           }
         ],
         "successComment": false,


### PR DESCRIPTION
- Update .releaserc to specify only .js and .css files in dist/ as GitHub release assets.
- Ensures only real distribution files are attached to GitHub releases.
- No changes to library code or build output.