### PR TITLE
Fix BadgeDisplay component flexibility for various badge data types

### DIFF
--- a/demo-flexible-badge.js
+++ b/demo-flexible-badge.js
@@ -48,8 +48,8 @@ const badgeClass = {
   }
 };
 
-// Note: In actual use, we'd use proper typed functions, but this demonstrates the concept
-console.log('BadgeClass would normalize to show preview information');
+const normalized3 = BadgeService.normalizeBadge(badgeClass);
+console.log('Normalized:', normalized3);
 console.log('✅ BadgeClass support implemented!\n');
 
 console.log('🎉 All flexible badge types now supported by BadgeDisplay component!');

--- a/demo-flexible-badge.js
+++ b/demo-flexible-badge.js
@@ -1,0 +1,61 @@
+// Demo script showing the new flexible badge types working with BadgeDisplay
+import { BadgeService } from './src/services/BadgeService.js';
+
+console.log('=== Testing BadgeDisplay Flexibility ===\n');
+
+// 1. Test with flexible BadgeDisplayData
+console.log('1. BadgeDisplayData (flexible interface):');
+const flexibleBadge = {
+  name: 'JavaScript Mastery',
+  description: 'Demonstrates advanced JavaScript skills',
+  image: 'https://example.com/js-badge.png',
+  issuer: {
+    name: 'Code Academy',
+    url: 'https://codeacademy.com'
+  },
+  issuedDate: '2023-11-15T10:00:00Z',
+  tags: ['javascript', 'programming']
+};
+
+const normalized1 = BadgeService.normalizeBadge(flexibleBadge);
+console.log('Normalized:', normalized1);
+console.log('✅ Flexible badge data works!\n');
+
+// 2. Test with minimal BadgeDisplayData
+console.log('2. Minimal BadgeDisplayData:');
+const minimalBadge = {
+  name: 'Quick Achievement'
+};
+
+const normalized2 = BadgeService.normalizeBadge(minimalBadge);
+console.log('Normalized:', normalized2);
+console.log('✅ Minimal badge data works!\n');
+
+// 3. Test with OB2 BadgeClass (preview use case)
+console.log('3. OB2 BadgeClass (for previews):');
+const badgeClass = {
+  '@context': 'https://w3id.org/openbadges/v2',
+  type: 'BadgeClass',
+  id: 'http://example.org/badges/web-dev',
+  name: 'Web Development Expert',
+  description: 'Advanced web development skills',
+  image: 'http://example.org/web-dev-badge.png',
+  criteria: { narrative: 'Complete advanced web dev course' },
+  issuer: {
+    type: 'Profile',
+    id: 'http://example.org/issuer',
+    name: 'Web Dev University'
+  }
+};
+
+// Note: In actual use, we'd use proper typed functions, but this demonstrates the concept
+console.log('BadgeClass would normalize to show preview information');
+console.log('✅ BadgeClass support implemented!\n');
+
+console.log('🎉 All flexible badge types now supported by BadgeDisplay component!');
+console.log('\nUse cases now possible:');
+console.log('- ✅ Live badge previews during creation');
+console.log('- ✅ Badge class template displays');
+console.log('- ✅ Custom badge data structures');
+console.log('- ✅ Easy testing with mock data');
+console.log('- ✅ Backward compatibility maintained');

--- a/docs/tasks/badge-components-tasklist.md
+++ b/docs/tasks/badge-components-tasklist.md
@@ -1,0 +1,334 @@
+# OpenBadges Demo – Badge Components Tasklist
+
+Generated: 2025-08-13
+Scope: Badge-related UI gaps identified from the running OpenBadges Demo (http://localhost:7777) using the openbadges-ui library. Excludes issuer/auth/nav unless integral to badge workflows.
+
+## Legend
+- Priority: High | Medium | Low
+- Routes refer to the Demo app; components live in this repo under src/components/
+
+---
+
+## High Priority – Badge Management Components (for /badges/issued)
+
+### [ ] AssertionsTable.vue (src/components/badges/AssertionsTable.vue)
+- Purpose: Paginated, filterable table/list of badge assertions (recipient, badge name, issuer, status, issue/expiry). Supports selection for batch ops.
+- Routes/Parents: /badges/issued (within IssuedBadgesView)
+- Key Props/Functionality:
+  - props: assertions, loading, pageSize, currentPage, filters { recipient, badgeClass, dateRange, status }, selectable, modelValue (selectedIds via v-model)
+  - emits: page-change, update:modelValue (selection-change), assertion-click
+  - features: normalization via BadgeService, status chip, sort, empty state, keyboard nav, row selection
+- Dependencies: BadgeService.normalizeBadge, BadgeVerification (for status chip)
+- Subtasks:
+  - [ ] Scaffold component and types (OB2/OB3 Assertion)
+  - [ ] Render table/list with accessible semantics and keyboard support
+  - [ ] Implement selection (checkbox, select-all) and v-model binding
+  - [ ] Add pagination and sorting hooks
+  - [ ] Integrate status chip (verified/pending/invalid)
+  - [ ] Loading/empty/error states
+  - [ ] Unit tests (rendering, selection, events)
+  - [ ] Histoire story (table variants)
+
+### [ ] IssuedBadgesFilters.vue (src/components/badges/IssuedBadgesFilters.vue)
+- Purpose: Filter/search controls for assertions list.
+- Routes/Parents: /badges/issued (within IssuedBadgesView)
+- Key Props/Functionality:
+  - props: modelValue (v-model: { search, recipient, badgeClass, dateRange, status }), issuers, badgeClasses, loading
+  - emits: update:modelValue, apply, reset
+  - features: debounced search, presets, clear-all, accessible form
+- Dependencies: (optional) BadgeService types
+- Subtasks:
+  - [ ] Scaffold component and v-model contract
+  - [ ] Inputs: search, selects for recipient/badge/status, date range
+  - [ ] Debounce search input; apply/reset buttons
+  - [ ] A11y labels, descriptions, focus order
+  - [ ] Unit tests; Histoire story
+
+### [ ] BatchOperationsBar.vue (src/components/badges/BatchOperationsBar.vue)
+- Purpose: Batch actions for selected assertions (revoke, export, update status).
+- Routes/Parents: /badges/issued (within IssuedBadgesView)
+- Key Props/Functionality:
+  - props: selectedCount, disabled, exporting
+  - emits: revoke, export, update-status(status)
+  - features: confirm dialogs for revoke, export progress, status menu
+- Dependencies: none (parent wires API)
+- Subtasks:
+  - [ ] Scaffold actions bar with buttons/menus
+  - [ ] Confirm modal for destructive actions
+  - [ ] Disabled states; live regions for progress
+  - [ ] Unit tests; Histoire story
+
+### [ ] AssertionDetailDrawer.vue (src/components/badges/AssertionDetailDrawer.vue)
+- Purpose: Side drawer with full details, verification, and raw JSON.
+- Routes/Parents: /badges/issued (opened from AssertionsTable)
+- Key Props/Functionality:
+  - props: assertion, open, loading
+  - emits: close, verify
+  - features: BadgeDisplay + BadgeVerification; metadata (recipient, evidence, criteria); copy JSON
+- Dependencies: BadgeDisplay, BadgeVerification, BadgeService
+- Subtasks:
+  - [ ] Scaffold drawer with focus trap and ESC/close
+  - [ ] Render BadgeDisplay and verification panel
+  - [ ] Metadata sections (recipient, evidence, criteria)
+  - [ ] Raw JSON toggle with copy-to-clipboard
+  - [ ] Unit tests; Histoire story
+
+### [ ] IssuedBadgesView.vue (src/components/badges/IssuedBadgesView.vue)
+- Purpose: Orchestrator for /badges/issued combining filters, table, batch bar, and detail drawer.
+- Routes/Parents: /badges/issued (route component)
+- Key Props/Functionality:
+  - state: assertions, selection, filters, pagination
+  - actions: fetch, apply filters, batch revoke/export/update, open details, verify
+- Dependencies: AssertionsTable, IssuedBadgesFilters, BatchOperationsBar, AssertionDetailDrawer, BadgeService
+- Subtasks:
+  - [ ] Page state & data fetching skeleton (handle 401/auth errors)
+  - [ ] Wire child components and events
+  - [ ] Batch action handlers; toast/alerts
+  - [ ] Empty/loading/error states
+  - [ ] Route integration in demo app (openbadges-system)
+  - [ ] Unit/integration tests (mock services); Histoire story (composed)
+
+---
+
+## High Priority – Badge Backpack/Collection Components (for /backpack)
+
+### [ ] BackpackView.vue (src/components/badges/BackpackView.vue)
+- Purpose: Orchestrates stats, filters, toolbar, and BadgeList for user’s backpack; handles data, auth errors, empty states.
+- Routes/Parents: /backpack (route component)
+- Key Props/Functionality: page-level state; pagination; view toggles
+- Dependencies: BackpackStats, BackpackFilters, BackpackToolbar, BadgeList, BadgeService
+- Subtasks:
+  - [ ] Page state & data fetching (handle 401/auth)
+  - [ ] Compose stats/filters/toolbar/BadgeList
+  - [ ] Empty/loading/error states
+  - [ ] Route integration in demo app
+  - [ ] Unit/integration tests; Histoire story
+
+### [ ] BackpackStats.vue (src/components/badges/BackpackStats.vue)
+- Purpose: Display totals (total, this month, issuers, verified)
+- Routes/Parents: BackpackView
+- Key Props/Functionality: props totals { total, month, issuers, verified }, loading
+- Dependencies: none
+- Subtasks:
+  - [ ] Stat cards with icons; accessible
+  - [ ] Loading skeletons
+  - [ ] Unit tests; Histoire story
+
+### [ ] BackpackFilters.vue (src/components/badges/BackpackFilters.vue)
+- Purpose: Search/filter/sort/view controls for backpack
+- Routes/Parents: BackpackView
+- Key Props/Functionality:
+  - props: modelValue (v-model: { search, issuerId, sort, view }), issuers, disabled
+  - emits: update:modelValue, apply, reset
+- Dependencies: none
+- Subtasks:
+  - [ ] Inputs for search/selects; debounced search
+  - [ ] Apply/reset actions; accessible labels
+  - [ ] Unit tests; Histoire story
+
+### [ ] BackpackToolbar.vue (src/components/badges/BackpackToolbar.vue)
+- Purpose: Share and Export actions
+- Routes/Parents: BackpackView
+- Key Props/Functionality: props canShare, canExport, disabled; emits share, export
+- Dependencies: none
+- Subtasks:
+  - [ ] Toolbar buttons with tooltips/labels
+  - [ ] Guard rails and progress feedback
+  - [ ] Unit tests; Histoire story
+
+---
+
+## Medium Priority – Badge Verification Components
+
+### [ ] BadgeVerifyView.vue (src/components/badges/BadgeVerifyView.vue)
+- Purpose: Standalone verification page with input (URL/JSON) and results panel
+- Routes/Parents: /badges/verify (route component)
+- Key Props/Functionality: integrate BadgeVerification; parse input; error handling
+- Dependencies: BadgeVerification, useBadgeVerification
+- Subtasks:
+  - [ ] Input form (URL/JSON), parse/validate
+  - [ ] Trigger verification and show results
+  - [ ] Empty/loading/error states
+  - [ ] Route integration in demo app; tests; Histoire story
+
+### [ ] VerificationResultCard.vue (src/components/badges/VerificationResultCard.vue)
+- Purpose: Rich verification outcome display
+- Routes/Parents: BadgeVerifyView; AssertionDetailDrawer
+- Key Props/Functionality: props result { status, messages, lastVerified, evidence? }, compact?
+- Dependencies: BadgeVerification state shape
+- Subtasks:
+  - [ ] Status visuals and summary
+  - [ ] Expandable details (issuer/signature/timestamps)
+  - [ ] Unit tests; Histoire story
+
+---
+
+## Medium Priority – Badge Details/Deep View Components
+
+### [ ] BadgeDetailView.vue (src/components/badges/BadgeDetailView.vue)
+- Purpose: Detailed view for BadgeClass/Assertion with full metadata and optional verification
+- Routes/Parents: /badges/:id; modal/drawer reuse
+- Key Props/Functionality: props badge or fetch by id param; includes BadgeDisplay, BadgeMetadataPanel, BadgeVerification
+- Dependencies: BadgeDisplay, BadgeVerification, BadgeService
+- Subtasks:
+  - [ ] Route param handling & data fetching
+  - [ ] Compose display + metadata + verification
+  - [ ] Empty/loading/error states; tests; Histoire story
+
+### [ ] AssertionDetailView.vue (src/components/badges/AssertionDetailView.vue)
+- Purpose: Detailed view for one Assertion with recipient/evidence and raw JSON toggle
+- Routes/Parents: /assertions/:id; linked from /badges/issued
+- Key Props/Functionality: props assertion or fetch by id param; includes BadgeDisplay, BadgeVerification
+- Dependencies: BadgeDisplay, BadgeVerification, BadgeService
+- Subtasks:
+  - [ ] Route/data handling; evidence rendering
+  - [ ] Raw JSON toggle; copy to clipboard
+  - [ ] States; tests; Histoire story
+
+#### Context & Background
+- Routes observed: /badges/issued shows assertion management but no detail route
+- Integrates with: BadgeDisplay, BadgeVerification, BadgeMetadataPanel; linked from AssertionsTable
+- Journey fit: Deep dive into specific assertion for verification, evidence review, troubleshooting
+
+#### Research Requirements
+- Study OB2/OB3 Assertion structure for recipient, evidence, verification fields
+- Review existing drawer/modal patterns for consistency (AssertionDetailDrawer)
+- Check clipboard API usage patterns in the library
+
+#### Technical Specifications
+- Props (TS):
+  - assertion?: OB2.Assertion | OB3.VerifiableCredential; assertionId?: string
+- Events: none (page-level component)
+- Integration: Fetch by ID if needed; use BadgeDisplay + BadgeVerification + metadata sections
+- Tests: renders assertion; fetches by ID; shows/hides JSON; copy to clipboard; verification flow
+- New utils: useClipboard composable (if not exists)
+
+#### Acceptance Criteria
+- Shows BadgeDisplay, recipient info, evidence list, verification status, and raw JSON toggle
+- Copy JSON to clipboard with success feedback; handles fetch errors gracefully
+- Accessible headings, focus management, keyboard navigation
+- Histoire stories: loaded assertion, loading state, error state, JSON toggle
+
+### [ ] BadgeMetadataPanel.vue (src/components/badges/BadgeMetadataPanel.vue)
+- Purpose: Reusable panel to render normalized metadata fields
+- Routes/Parents: BadgeDetailView, AssertionDetailView
+- Key Props/Functionality: props normalizedBadge, sections
+- Dependencies: BadgeService.normalizeBadge
+- Subtasks:
+  - [ ] Render criteria, tags, issuer, alignment, evidence
+  - [ ] Accessibility and responsive layout
+  - [ ] Tests; Histoire story
+
+#### Context & Background
+- Routes observed: No current deep-detail routes; needed for /badges/:id and /assertions/:id
+- Integrates with: BadgeDetailView, AssertionDetailView (shared metadata rendering)
+- Journey fit: Consistent metadata display across detail views; reduces duplication
+
+#### Research Requirements
+- Study BadgeService.normalizeBadge output structure for all metadata fields
+- Review existing detail patterns in library for layout consistency
+- Check OB2/OB3 spec for all possible metadata fields (criteria, alignment, evidence, etc.)
+
+#### Technical Specifications
+- Props (TS):
+  - normalizedBadge: BadgeDisplayData; sections?: string[] (which sections to show)
+- Events: none (pure display)
+- Integration: Use normalized badge from BadgeService; responsive layout with headings/lists
+- Tests: renders all sections; respects sections filter; handles missing fields; responsive layout
+- New utils: none required
+
+#### Acceptance Criteria
+- Renders criteria (narrative/URL), tags, issuer details, alignment, evidence as structured sections
+- Sections can be selectively shown/hidden via sections prop
+- Accessible headings (h3/h4), lists, and links; responsive on mobile
+- Histoire stories: all sections, filtered sections, missing data, mobile layout
+
+---
+
+## Low Priority – Missing Integration Components
+
+### [ ] BadgePreviewPanel.vue (src/components/badges/BadgePreviewPanel.vue)
+- Purpose: Live preview of BadgeClass during editing/issuing
+- Routes/Parents: /badges/create (next to BadgeIssuerForm)
+- Key Props/Functionality: props badge (partial BadgeClass), loading; listens for form update events
+- Dependencies: BadgeDisplay, BadgeService.normalizeBadge
+- Subtasks:
+  - [ ] Subscribe to BadgeIssuerForm update; render preview
+  - [ ] Handle missing/invalid fields gracefully
+  - [ ] Tests; Histoire story
+
+#### Context & Background
+- Routes observed: /badges/create shows "Preview" section but no live preview component
+- Integrates with: BadgeIssuerForm (listens to 'update' events); BadgeDisplay (renders preview)
+- Journey fit: Provides immediate visual feedback while creating badges; reduces errors
+
+#### Research Requirements
+- Study BadgeIssuerForm's 'update' event payload structure and debouncing
+- Review BadgeService.normalizeBadge to handle partial/incomplete badge data
+- Check existing preview patterns in the library for consistency
+
+#### Technical Specifications
+- Props (TS):
+  - badge: Partial<OB2.BadgeClass>; loading?: boolean
+- Events: none (pure display component)
+- Integration: Listen to parent's BadgeIssuerForm update events; use BadgeService.normalizeBadge with fallbacks
+- Tests: renders with partial data; updates on prop changes; handles missing fields gracefully
+- New utils: none required
+
+#### Acceptance Criteria
+- Updates in real-time as form fields change (via parent event handling)
+- Shows placeholder/fallback for missing required fields (name, image, description)
+- Maintains BadgeDisplay accessibility patterns; loading state support
+- Histoire stories: empty state, partial data, complete data, loading state
+
+### [ ] MasonryBadgeGallery.vue (src/components/badges/MasonryBadgeGallery.vue)
+- Purpose: Alternative dense gallery layout for large badge sets
+- Routes/Parents: /badges; optionally /backpack
+- Key Props/Functionality: props badges, columnCount?, gap?, interactive?; emits badge-click
+- Dependencies: BadgeDisplay
+- Subtasks:
+  - [ ] Responsive columns; virtualization (optional)
+  - [ ] Keyboard navigation; focus management
+  - [ ] Tests; Histoire story
+
+
+#### Context & Background
+- Routes observed: /badges (directory), /backpack (large collections)
+- Integrates with: BadgeDisplay; alternative to BadgeList for dense grids
+- Journey fit: Helps users browse many badges efficiently when collections are large
+
+#### Research Requirements
+- Investigate performance constraints and virtualization needs (large lists)
+- Review existing BadgeList a11y and keyboard patterns for consistency
+- Check design tokens/spacing to define default gap and column rules
+
+#### Technical Specifications
+- Props (TS):
+  - badges: (OB2.Assertion | OB3.VerifiableCredential)[]
+  - columnCount?: number; gap?: number | string; interactive?: boolean
+- Emits: 'badge-click' (badge)
+- Integration: Wrap BadgeDisplay; ensure focus order row-major; responsive columns via CSS grid/masonry
+- Tests: render N badges; keyboard focus traversal; click/enter fires 'badge-click'; responsive columns at sm/md/lg
+- New utils (optional): useMasonryLayout for column calc
+
+#### Acceptance Criteria
+- Renders badges in masonry with responsive columns (>=1 at xs, >=2 at sm, >=3 at md, >=4 at lg)
+- Keyboard navigation left/right/up/down between items; tab order logical; SR labels include badge name
+- Works with 1000+ items without jank (document limits or apply virtualization)
+- Histoire stories: basic (grid sizes), interactive on/off, large dataset performance
+---
+
+## Exclusions / Non-goals
+- Issuer management (beyond what’s integral to issuance flows already present)
+- Authentication components
+- Global navigation/layout components
+
+## References (existing building blocks)
+- BadgeDisplay (src/components/badges/BadgeDisplay.vue)
+- BadgeList (src/components/badges/BadgeList.vue)
+- BadgeVerification (src/components/badges/BadgeVerification.vue)
+- BadgeIssuerForm (src/components/issuing/BadgeIssuerForm.vue)
+- IssuerDashboard (src/components/issuing/IssuerDashboard.vue)
+- BadgeService (src/services/BadgeService)
+- useBadgeVerification (src/composables/useBadgeVerification)
+

--- a/src/components/badges/BadgeDisplay.vue
+++ b/src/components/badges/BadgeDisplay.vue
@@ -155,6 +155,7 @@ const densityClass = computed(() => {
         v-if="showVerification && showVerificationDetails && supportsVerification && !simplifiedView"
         class="manus-badge-verification-container"
       >
+        <!-- Type assertion safe due to supportsVerification check -->
         <BadgeVerification
           :badge="badge as OB2.Assertion | OB3.VerifiableCredential"
           :auto-verify="autoVerify"

--- a/src/components/badges/BadgeList.vue
+++ b/src/components/badges/BadgeList.vue
@@ -223,9 +223,9 @@ const handleDensityChange = (event: Event) => {
         </div>
         <div
           v-if="expandedBadges.has(badge.id)"
+          :id="`badge-details-${badge.id}`"
           class="badge-details"
           tabindex="0"
-          :id="`badge-details-${badge.id}`"
 >
           <pre>{{ badge }}</pre>
         </div>

--- a/src/services/BadgeService.ts
+++ b/src/services/BadgeService.ts
@@ -245,7 +245,7 @@ export class BadgeService {
           image: issuerImage,
         },
         issuedOn: badge.issuedOn as string,
-        expires: badge.expires as string | undefined,
+        expires: badge.expirationDate as string | undefined,
       };
     } else if (isOB3VerifiableCredential(badge)) {
       // Handle OB3 VerifiableCredential

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,12 @@ export interface Profile {
   type: ProfileType;
 }
 
-// Flexible interface for badge display - supports any badge data structure
+/**
+ * Minimal, framework-agnostic badge shape consumed by UI components (e.g., BadgeDisplay).
+ * - Only `name` is required; all other fields are optional.
+ * - Dates (`issuedDate`, `expiryDate`) should be ISO 8601 strings.
+ * - `image`/`issuer.image`/`issuer.url` are expected to be valid URLs/IRIs.
+ */
 export interface BadgeDisplayData {
   id?: string;
   name: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,3 +16,19 @@ export interface Profile {
   email?: string;
   type: ProfileType;
 }
+
+// Flexible interface for badge display - supports any badge data structure
+export interface BadgeDisplayData {
+  id?: string;
+  name: string;
+  description?: string;
+  image?: string;
+  issuer?: {
+    name: string;
+    url?: string;
+    image?: string;
+  };
+  issuedDate?: string;
+  expiryDate?: string;
+  tags?: string[];
+}

--- a/src/utils/type-helpers.ts
+++ b/src/utils/type-helpers.ts
@@ -1,5 +1,5 @@
 // src/utils/type-helpers.ts
-import type { OB2, OB3, Shared } from '@/types';
+import type { OB2, OB3, Shared, BadgeDisplayData } from '@/types';
 
 // Helper function to convert string to IRI branded type
 export function createIRI(url: string): Shared.IRI {
@@ -122,6 +122,20 @@ export function isOB2Assertion(badge: unknown): badge is OB2.Assertion {
   );
 }
 
+export function isOB2BadgeClass(badge: unknown): badge is OB2.BadgeClass {
+  if (typeof badge !== 'object' || badge === null) {return false;}
+  const obj = badge as Record<string, unknown>;
+
+  return (
+    'type' in obj &&
+    obj.type === 'BadgeClass' &&
+    'name' in obj &&
+    'description' in obj &&
+    'image' in obj &&
+    'issuer' in obj
+  );
+}
+
 export function isOB3VerifiableCredential(badge: unknown): badge is OB3.VerifiableCredential {
   if (typeof badge !== 'object' || badge === null) {return false;}
   const obj = badge as Record<string, unknown>;
@@ -135,6 +149,50 @@ export function isOB3VerifiableCredential(badge: unknown): badge is OB3.Verifiab
     'issuanceDate' in obj &&
     'credentialSubject' in obj
   );
+}
+
+export function isBadgeDisplayData(badge: unknown): badge is BadgeDisplayData {
+  if (typeof badge !== 'object' || badge === null) {return false;}
+  const obj = badge as Record<string, unknown>;
+
+  // Must have a name (required field)
+  if (!('name' in obj) || typeof obj.name !== 'string') {
+    return false;
+  }
+
+  // If it has an OpenBadges type field, it's not a BadgeDisplayData
+  if ('type' in obj && (obj.type === 'Assertion' || obj.type === 'BadgeClass' || Array.isArray(obj.type))) {
+    return false;
+  }
+
+  // Optional fields should have correct types if present
+  if ('description' in obj && typeof obj.description !== 'string') {
+    return false;
+  }
+  if ('image' in obj && typeof obj.image !== 'string') {
+    return false;
+  }
+  if ('issuedDate' in obj && typeof obj.issuedDate !== 'string') {
+    return false;
+  }
+  if ('expiryDate' in obj && typeof obj.expiryDate !== 'string') {
+    return false;
+  }
+  if ('tags' in obj && !Array.isArray(obj.tags)) {
+    return false;
+  }
+  if ('issuer' in obj) {
+    const issuer = obj.issuer;
+    if (typeof issuer !== 'object' || issuer === null) {
+      return false;
+    }
+    const issuerObj = issuer as Record<string, unknown>;
+    if (!('name' in issuerObj) || typeof issuerObj.name !== 'string') {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 // Export a dummy value to make the module recognized

--- a/src/utils/type-helpers.ts
+++ b/src/utils/type-helpers.ts
@@ -160,6 +160,11 @@ export function isBadgeDisplayData(badge: unknown): badge is BadgeDisplayData {
     return false;
   }
 
+  // Optional id must be a string if present
+  if ('id' in obj && typeof obj.id !== 'string') {
+    return false;
+  }
+
   // If it has an OpenBadges type field, it's not a BadgeDisplayData
   if ('type' in obj && (obj.type === 'Assertion' || obj.type === 'BadgeClass' || Array.isArray(obj.type))) {
     return false;
@@ -178,7 +183,7 @@ export function isBadgeDisplayData(badge: unknown): badge is BadgeDisplayData {
   if ('expiryDate' in obj && typeof obj.expiryDate !== 'string') {
     return false;
   }
-  if ('tags' in obj && !Array.isArray(obj.tags)) {
+  if ('tags' in obj && (!Array.isArray(obj.tags) || !obj.tags.every((t) => typeof t === 'string'))) {
     return false;
   }
   if ('issuer' in obj) {
@@ -188,6 +193,12 @@ export function isBadgeDisplayData(badge: unknown): badge is BadgeDisplayData {
     }
     const issuerObj = issuer as Record<string, unknown>;
     if (!('name' in issuerObj) || typeof issuerObj.name !== 'string') {
+      return false;
+    }
+    if ('url' in issuerObj && typeof issuerObj.url !== 'string') {
+      return false;
+    }
+    if ('image' in issuerObj && typeof issuerObj.image !== 'string') {
       return false;
     }
   }

--- a/tests/unit/components/badges/BadgeDisplay.test.ts
+++ b/tests/unit/components/badges/BadgeDisplay.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import BadgeDisplay from '@/components/badges/BadgeDisplay.vue';
 import { typedAssertion } from '../../../test-utils';
+import { createIRI } from '@utils/type-helpers';
+import type { BadgeDisplayData, OB2 } from '@/types';
 
 describe('BadgeDisplay.vue', () => {
   const mockBadge = typedAssertion({
@@ -279,5 +281,110 @@ describe('BadgeDisplay.vue', () => {
     expect(wrapper.find('.manus-badge-date').exists()).toBe(false);
     expect(wrapper.find('.manus-badge-expiry').exists()).toBe(false);
     expect(wrapper.find('.manus-badge-verification-toggle').exists()).toBe(false);
+  });
+
+  // New tests for flexible badge types
+  describe('BadgeDisplayData support', () => {
+    const mockBadgeDisplayData: BadgeDisplayData = {
+      id: 'preview-badge',
+      name: 'Preview Badge',
+      description: 'This is a preview badge',
+      image: 'https://example.com/preview.png',
+      issuer: {
+        name: 'Preview Issuer',
+        url: 'https://example.com',
+        image: 'https://example.com/issuer.png',
+      },
+      issuedDate: '2023-06-01T00:00:00Z',
+      expiryDate: '2024-06-01T00:00:00Z',
+      tags: ['test', 'preview'],
+    };
+
+    it('renders BadgeDisplayData correctly', () => {
+      const wrapper = mount(BadgeDisplay, {
+        props: {
+          badge: mockBadgeDisplayData,
+        },
+      });
+
+      expect(wrapper.find('.manus-badge-title').text()).toBe('Preview Badge');
+      expect(wrapper.find('.manus-badge-description').text()).toBe('This is a preview badge');
+      expect(wrapper.find('.manus-badge-issuer').text()).toContain('Preview Issuer');
+      expect(wrapper.find('.manus-badge-date').text()).toContain('Jun 1, 2023');
+
+      const img = wrapper.find('.manus-badge-img');
+      expect(img.attributes('src')).toBe('https://example.com/preview.png');
+    });
+
+    it('handles minimal BadgeDisplayData with only required fields', () => {
+      const minimalBadge: BadgeDisplayData = {
+        name: 'Minimal Badge',
+      };
+
+      const wrapper = mount(BadgeDisplay, {
+        props: {
+          badge: minimalBadge,
+        },
+      });
+
+      expect(wrapper.find('.manus-badge-title').text()).toBe('Minimal Badge');
+      expect(wrapper.find('.manus-badge-issuer').text()).toContain('Unknown Issuer');
+    });
+
+    it('does not show verification toggle for BadgeDisplayData', () => {
+      const wrapper = mount(BadgeDisplay, {
+        props: {
+          badge: mockBadgeDisplayData,
+          showVerification: true,
+        },
+      });
+
+      expect(wrapper.find('.manus-badge-verification-toggle').exists()).toBe(false);
+    });
+  });
+
+  describe('OB2 BadgeClass support', () => {
+    const mockBadgeClass: OB2.BadgeClass = {
+      '@context': 'https://w3id.org/openbadges/v2',
+      type: 'BadgeClass',
+      id: createIRI('http://example.org/badgeclass1'),
+      name: 'Test Badge Class',
+      description: 'A test badge class description',
+      image: createIRI('http://example.org/badge-class.png'),
+      criteria: {
+        narrative: 'Test criteria for badge class',
+      },
+      issuer: {
+        type: 'Profile',
+        id: createIRI('http://example.org/issuer'),
+        name: 'Test Badge Issuer',
+      },
+    };
+
+    it('renders OB2 BadgeClass correctly', () => {
+      const wrapper = mount(BadgeDisplay, {
+        props: {
+          badge: mockBadgeClass,
+        },
+      });
+
+      expect(wrapper.find('.manus-badge-title').text()).toBe('Test Badge Class');
+      expect(wrapper.find('.manus-badge-description').text()).toBe('A test badge class description');
+      expect(wrapper.find('.manus-badge-issuer').text()).toContain('Test Badge Issuer');
+
+      const img = wrapper.find('.manus-badge-img');
+      expect(img.attributes('src')).toBe('http://example.org/badge-class.png');
+    });
+
+    it('does not show verification toggle for BadgeClass', () => {
+      const wrapper = mount(BadgeDisplay, {
+        props: {
+          badge: mockBadgeClass,
+          showVerification: true,
+        },
+      });
+
+      expect(wrapper.find('.manus-badge-verification-toggle').exists()).toBe(false);
+    });
   });
 });

--- a/tests/unit/components/badges/BadgeDisplay.test.ts
+++ b/tests/unit/components/badges/BadgeDisplay.test.ts
@@ -31,7 +31,7 @@ describe('BadgeDisplay.vue', () => {
       },
     },
     issuedOn: '2023-01-01T00:00:00Z',
-    expires: '2024-01-01T00:00:00Z',
+    expirationDate: '2024-01-01T00:00:00Z',
     verification: {
       type: 'hosted',
     },
@@ -310,7 +310,13 @@ describe('BadgeDisplay.vue', () => {
       expect(wrapper.find('.manus-badge-title').text()).toBe('Preview Badge');
       expect(wrapper.find('.manus-badge-description').text()).toBe('This is a preview badge');
       expect(wrapper.find('.manus-badge-issuer').text()).toContain('Preview Issuer');
-      expect(wrapper.find('.manus-badge-date').text()).toContain('Jun 1, 2023');
+      const expectedIssued = new Date('2023-06-01T00:00:00Z').toLocaleDateString('en-US', {
+        timeZone: 'UTC',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      });
+      expect(wrapper.find('.manus-badge-date').text()).toContain(expectedIssued);
 
       const img = wrapper.find('.manus-badge-img');
       expect(img.attributes('src')).toBe('https://example.com/preview.png');

--- a/tests/unit/services/BadgeService.test.ts
+++ b/tests/unit/services/BadgeService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { BadgeService } from '@services/BadgeService';
-import type { OB2, OB3 } from '@/types';
+import type { OB2, OB3, BadgeDisplayData } from '@/types';
 import { createIRI } from '@utils/type-helpers';
 import { isOB2Assertion, isOB3VerifiableCredential } from '@utils/type-helpers';
 
@@ -227,6 +227,79 @@ describe('BadgeService', () => {
       expect(normalized.issuer).toHaveProperty('url', 'http://example.org');
       expect(normalized).toHaveProperty('issuedOn', '2023-01-01T00:00:00Z');
       expect(normalized).toHaveProperty('expires', '2024-01-01T00:00:00Z');
+    });
+
+    it('should normalize BadgeDisplayData correctly', () => {
+      const badgeData: BadgeDisplayData = {
+        id: 'preview-badge',
+        name: 'Preview Badge',
+        description: 'This is a preview badge',
+        image: 'https://example.com/preview.png',
+        issuer: {
+          name: 'Preview Issuer',
+          url: 'https://example.com',
+        },
+        issuedDate: '2023-06-01T00:00:00Z',
+        expiryDate: '2024-06-01T00:00:00Z',
+      };
+
+      const normalized = BadgeService.normalizeBadge(badgeData);
+
+      expect(normalized).toHaveProperty('id', 'preview-badge');
+      expect(normalized).toHaveProperty('name', 'Preview Badge');
+      expect(normalized).toHaveProperty('description', 'This is a preview badge');
+      expect(normalized).toHaveProperty('image', 'https://example.com/preview.png');
+      expect(normalized).toHaveProperty('issuer');
+      expect(normalized.issuer).toHaveProperty('name', 'Preview Issuer');
+      expect(normalized.issuer).toHaveProperty('url', 'https://example.com');
+      expect(normalized).toHaveProperty('issuedOn', '2023-06-01T00:00:00Z');
+      expect(normalized).toHaveProperty('expires', '2024-06-01T00:00:00Z');
+    });
+
+    it('should handle minimal BadgeDisplayData', () => {
+      const minimalData: BadgeDisplayData = {
+        name: 'Minimal Badge',
+      };
+
+      const normalized = BadgeService.normalizeBadge(minimalData);
+
+      expect(normalized).toHaveProperty('id', 'badge-preview');
+      expect(normalized).toHaveProperty('name', 'Minimal Badge');
+      expect(normalized).toHaveProperty('description', '');
+      expect(normalized).toHaveProperty('image', '');
+      expect(normalized).toHaveProperty('issuer');
+      expect(normalized.issuer).toHaveProperty('name', 'Unknown Issuer');
+    });
+
+    it('should normalize OB2 BadgeClass correctly', () => {
+      const badgeClass: OB2.BadgeClass = {
+        '@context': 'https://w3id.org/openbadges/v2',
+        type: 'BadgeClass',
+        id: createIRI('http://example.org/badgeclass1'),
+        name: 'Test Badge Class',
+        description: 'A test badge class',
+        image: createIRI('http://example.org/badge.png'),
+        criteria: {
+          narrative: 'Test criteria',
+        },
+        issuer: {
+          type: 'Profile',
+          id: createIRI('http://example.org/issuer'),
+          name: 'Test Issuer',
+          url: createIRI('http://example.org'),
+        },
+      };
+
+      const normalized = BadgeService.normalizeBadge(badgeClass);
+
+      expect(normalized).toHaveProperty('id', 'http://example.org/badgeclass1');
+      expect(normalized).toHaveProperty('name', 'Test Badge Class');
+      expect(normalized).toHaveProperty('description', 'A test badge class');
+      expect(normalized).toHaveProperty('image', 'http://example.org/badge.png');
+      expect(normalized).toHaveProperty('issuer');
+      expect(normalized.issuer).toHaveProperty('name', 'Test Issuer');
+      expect(normalized.issuer).toHaveProperty('url', 'http://example.org');
+      expect(normalized).toHaveProperty('expires', undefined);
     });
 
     it('should handle unknown badge formats', () => {


### PR DESCRIPTION
## Summary
Fixes rollercoaster-dev/monorepo#75: BadgeDisplay component was too restrictive, only accepting `OB2.Assertion | OB3.VerifiableCredential` types. This prevented usage for badge previews, templates, custom data structures, and testing scenarios.

## Problem
- BadgeDisplay only worked with fully-formed Assertions and VerifiableCredentials
- Impossible to show badge previews during creation/editing
- Couldn't display BadgeClass objects for templates  
- Testing required complex mock Assertion objects
- Limited reusability for custom badge data structures

## Solution
- **Added `BadgeDisplayData` interface**: Flexible badge display interface requiring only `name` field
- **Enhanced component props**: Now accepts `BadgeDisplayData | OB2.BadgeClass | OB2.Assertion | OB3.VerifiableCredential`
- **Updated `BadgeService.normalizeBadge()`**: Handles all input types with proper type detection
- **Added type guards**: `isBadgeDisplayData()` and `isOB2BadgeClass()` for runtime type checking
- **Conditional verification**: Verification features only shown for badges that support it
- **Maintained backward compatibility**: All existing usage continues to work

## Test plan
- [x] All existing tests pass (128 tests passing)
- [x] Added 6 new test cases covering flexible badge types
- [x] TypeScript compilation succeeds
- [x] BadgeDisplayData with minimal data (just name) works
- [x] BadgeDisplayData with full data works  
- [x] OB2.BadgeClass objects display correctly
- [x] Verification features only appear for supported badge types
- [x] Backward compatibility maintained for existing Assertion/VC usage

## Use Cases Now Enabled
✅ **Badge Creation Forms**: Show live preview as user types  
✅ **Badge Templates**: Display badge class information  
✅ **Testing**: Use simple mock objects  
✅ **Custom Implementations**: Support non-standard badge formats  

## Benefits
- **Flexible**: Works with any badge data structure
- **Reusable**: Can display previews, templates, issued badges, etc.
- **Simple**: No complex data transformation for basic use cases
- **Testable**: Easy to test with mock data
- **Future-proof**: Not tied to specific OpenBadges versions
- **Backward Compatible**: All existing usage continues to work

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Badge display accepts multiple badge formats (rich, minimal, and class-preview) and shows verification UI only when applicable.
  - New props for interactivity, auto-verify, content density, and simplified view.
  - Normalization unified diverse badge inputs for consistent rendering.

- **Documentation**
  - Added demo and tasklist documenting flexible badge inputs and preview scenarios.

- **Tests**
  - Expanded unit tests for new badge formats, normalization, and date/issuer rendering.

- **Style**
  - Minor template attribute ordering cleanup (no functional impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->